### PR TITLE
Update for latest homestead.  Ubuntu 18.X needs msodbcsql 17.x

### DIFF
--- a/aliases
+++ b/aliases
@@ -255,12 +255,12 @@ function install_sqlserver_php7.1() {
     apt-get update && apt-get install -y apt-transport-https
 
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-    curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+    curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
     apt-get update
     ACCEPT_EULA=Y apt-get -y install \
           php7.1 mcrypt php7.1-mcrypt php-mbstring php-pear php7.1-dev php7.1-xml \
-          msodbcsql mssql-tools unixodbc-dev
+          msodbcsql17 mssql-tools unixodbc-dev
 
     echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
     echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc


### PR DESCRIPTION
Followed instructions here: https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-2017#ubuntu-1404-1604-1710-and-1804 homestead is on 18.04 now so according to the note, needs driver 17.2